### PR TITLE
Changes needed to allow GNU build of wave GEOS

### DIFF
--- a/model/ftn/wmmaplmd.ftn
+++ b/model/ftn/wmmaplmd.ftn
@@ -144,7 +144,10 @@
       use WMWAVEMD, only: WMWAVE
       use WMFINLMD, only: WMFINL
       use WMMDATMD
-      use W3GDATMD
+      ! We rename the derived type GRID from W3GDATMD to W3GRID to avoid
+      ! a name clash with an ESMF_Grid called "grid" declared below.
+      ! This was detected by GNU
+      use W3GDATMD, W3GRID => GRID
       use W3IDATMD
       use W3ODATMD
       use W3WDATMD


### PR DESCRIPTION
Supersedes #3 

Working off of the components in https://github.com/GEOS-ESM/GEOSgcm/pull/724, this PR along with https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/876 contains changes needed to allow Wave GEOS to build with GNU. 

The change is a small one in `wmmaplmd.ftn`:
```diff
diff --git a/model/ftn/wmmaplmd.ftn b/model/ftn/wmmaplmd.ftn
index 218a927a..c0f3347a 100644
--- a/model/ftn/wmmaplmd.ftn
+++ b/model/ftn/wmmaplmd.ftn
@@ -144,7 +144,10 @@
       use WMWAVEMD, only: WMWAVE
       use WMFINLMD, only: WMFINL
       use WMMDATMD
-      use W3GDATMD
+      ! We rename the derived type GRID from W3GDATMD to W3GRID to avoid
+      ! a name clash with an ESMF_Grid called "grid" declared below.
+      ! This was detected by GNU
+      use W3GDATMD, W3GRID => GRID
       use W3IDATMD
       use W3ODATMD
       use W3WDATMD
```

GNU was erroring out with:
```
/discover/swdev/mathomp4/Models/GEOSgcm-AntonWave-GNU/GEOSgcm/build-Release/src/Components/@GEOSgcm_GridComp/GEOSwgcm_GridComp/GEOSwavewatch_GridComp/ww3_multi_esmf/wmmaplmd.F90:2156:37:

 2156 |       call ESMF_GridCompGet(gc, grid=grid, __RC__)
      |                                     1
Error: Derived type 'grid' is used as an actual argument at (1)
/discover/swdev/mathomp4/Models/GEOSgcm-AntonWave-GNU/GEOSgcm/build-Release/src/Components/@GEOSgcm_GridComp/GEOSwgcm_GridComp/GEOSwavewatch_GridComp/ww3_multi_esmf/wmmaplmd.F90:2157:30:

 2157 |       call MAPL_Grid_Interior(grid, i1, in, j1, jn)
      |                              1
Error: Derived type 'grid' is used as an actual argument at (1)
```

This is because the `use W3GDATMD` was bringing in a `GRID` derived type. So, in consult with @tclune we just rename the `GRID` coming from `W3GDATMD` to `W3GRID` so there is no conflict. (The other way around is to rename the ESMF_Grid...)